### PR TITLE
Treat orphan nodes as root nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ var groupByParents = function(array, options) {
 
   return array.reduce(function(prev, item) {
     var parentID = property.get(item, options.parentProperty);
-    if (!parentID || !(parentID in arrayByID)) {
+    if (!parentID || !arrayByID.hasOwnProperty(parentID)) {
       parentID = options.rootID;
     }
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var isArray = require('lodash.isarray');
 var assign = require('lodash.assign');
 var property = require('nested-property');
+var keyBy = require('lodash.keyby');
 
 var createTree = function(array, rootNodes, customID) {
   var tree = [];
@@ -25,8 +26,13 @@ var createTree = function(array, rootNodes, customID) {
 };
 
 var groupByParents = function(array, options) {
+  var arrayByID = keyBy(array, options.customID);
+
   return array.reduce(function(prev, item) {
-    var parentID = property.get(item, options.parentProperty) || options.rootID;
+    var parentID = property.get(item, options.parentProperty);
+    if (!parentID || !(parentID in arrayByID)) {
+      parentID = options.rootID;
+    }
 
     if (parentID && prev.hasOwnProperty(parentID)) {
       prev[parentID].push(item);

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "lodash.assign": "^4.0.6",
     "lodash.isarray": "^4.0.0",
+    "lodash.keyby": "^4.6.0",
     "nested-property": "^0.0.7"
   }
 }

--- a/test/fixtures/expected-orphan.fixture.js
+++ b/test/fixtures/expected-orphan.fixture.js
@@ -1,0 +1,15 @@
+module.exports = [{
+  id: 1,
+  parent_id: null,
+  children: [{
+    id: 2,
+    parent_id: 1,
+    children: [{
+      id: 3,
+      parent_id: 2
+    }]
+  }]
+}, {
+  id: 4,
+  parent_id: 5
+}];

--- a/test/fixtures/initial-orphan.fixture.js
+++ b/test/fixtures/initial-orphan.fixture.js
@@ -1,0 +1,13 @@
+module.exports = [{
+  id: 1,
+  parent_id: null
+}, {
+  id: 2,
+  parent_id: 1
+}, {
+  id: 3,
+  parent_id: 2
+}, {
+  id: 4,
+  parent_id: 5
+}];

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,8 @@ var customExpected = require('./fixtures/expected-custom.fixture.js');
 var customInitial = require('./fixtures/initial-custom.fixture.js');
 var nestedInitial = require('./fixtures/initial-nested.fixture.js');
 var nestedExpected = require('./fixtures/expected-nested.fixture.js');
+var orphanInitial = require('./fixtures/initial-orphan.fixture.js');
+var orphanExpected = require('./fixtures/expected-orphan.fixture.js');
 
 var current;
 
@@ -88,6 +90,12 @@ describe('array-to-tree', function() {
 
       expect(current)
         .to.be.deep.equal(nestedExpected);
+    });
+    it('should work with orphan nodes', function() {
+      current = toTree(orphanInitial);
+
+      expect(current)
+        .to.be.deep.equal(orphanExpected);
     });
   });
 });


### PR DESCRIPTION
Hello! In my application, you can filter the nodes, which results in some of the parent nodes being removed, leaving "orphans." This pull request considers nodes who have a parent that doesn't exist as root nodes. Hopefully this is useful beyond my use case :)