### PR TITLE
Bug Fix: Maximum call stack size exceeded

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ function groupByParents(array, options) {
 
   return array.reduce(function(prev, item) {
     var parentID = property.get(item, options.parentProperty);
-    if (!parentID || !arrayByID.hasOwnProperty(parentID)) {
+
+    if ( (parentID && !arrayByID.hasOwnProperty(parentID) ) ){
       parentID = options.rootID;
     }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/53438585/65182841-808ec080-da62-11e9-9f00-cdc99515dc7f.png)
parent_id = null / undefined / 0 caused this error
But the root node has no parent.
The bug should be fixed by the following change.